### PR TITLE
Add support for COLT 2022

### DIFF
--- a/code/paper_downloader_COLT.py
+++ b/code/paper_downloader_COLT.py
@@ -14,6 +14,7 @@ def download_paper(year, save_dir, is_download_supplement=False, time_step_in_se
     :return: True
     """
     COLT_year_dict = {
+        2022: 178,
         2021: 134,
         2020: 125,
         2019: 99,
@@ -43,10 +44,10 @@ def download_paper(year, save_dir, is_download_supplement=False, time_step_in_se
 
 
 if __name__ == '__main__':
-    year = 2021
+    year = 2022
     download_paper(
         year,
-        rf'D:\COLT_{year}',
+        rf'E:\COLT_{year}',
         is_download_supplement=False,
         time_step_in_seconds=3,
         downloader='IDM'


### PR DESCRIPTION
Add support for COLT 2022
Update COLT 2022 paper counting: 155 papers